### PR TITLE
fix(#4): run command use `--config` flag if passed

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -380,7 +380,7 @@ impl Backend {
 
         self.update(params.clone());
         if self.cli.is_installed() {
-            match self.cli.run(uri.path(), self.config_filter()) {
+            match self.cli.run(uri.path(), self.config_path(), self.config_filter()) {
                 Ok(result) => {
                     let mut diagnostics = Vec::new();
                     for (_, v) in result.iter() {

--- a/src/vale.rs
+++ b/src/vale.rs
@@ -159,11 +159,15 @@ impl ValeManager {
     pub(crate) fn run(
         &self,
         fp: &str,
+        config_path: String,
         filter: String,
     ) -> Result<HashMap<String, Vec<ValeAlert>>, Error> {
         let mut args = self.args.clone();
         let cwd = path::Path::new(fp).parent().unwrap();
 
+        if config_path != "" {
+            args.push(format!("--config={}", config_path));
+        }
         if filter != "" {
             args.push(format!("--filter={}", filter));
         }


### PR DESCRIPTION
This fixes the run command if the user uses a the configuration file on a different location than `$HOME`.

Note: This doesn't fix when installing vale, because on that case it will be needed to generate a `vale.ini` file, without that `vale` complains about not being able to find a configruationfile.