### PR TITLE
Update cargo version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "vale-ls"
 publish = false
-version = "0.1.0"
+version = "0.3.5"
 
 [dependencies]
 clap = {version = "4.2.1", features = ["derive"]}


### PR DESCRIPTION
`--version` prints "0.1.0" even though the installed version is 0.3.5

#3 