### PR TITLE
fix: 404'd link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ See the [documentation][4] for more information.
 [1]: https://microsoft.github.io/language-server-protocol/
 [2]: https://github.com/errata-ai/vale
 [3]: https://github.com/errata-ai/vale-ls/releases
-[4]: https://vale.sh/docs/integrations/guide/
+[4]: https://vale.sh/docs/guides/lsp


### PR DESCRIPTION
Update README link [4] to point to https://vale.sh/docs/guides/lsp

The original link https://vale.sh/docs/integrations/guide/ gives a 404 error now