### PR TITLE
Update release.yml to include Windows ARM64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: aarch64-pc-windows-gnu
+          - target: aarch64-pc-windows-msvc
             os: windows-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: aarch64-pc-windows-gnu
+            os: windows-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin


### PR DESCRIPTION
I don't even know if this is possible, but I can't test any Windows features right now as I need an ARM release to run Windows in an emulator on my Mac, so I wanted to at least see what happened on build runs.