### PR TITLE
Allow for custom binaries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,21 +8,31 @@ use vale_ls::vale::ValeManager;
 /// The official Vale Language Server.
 #[derive(Parser, Debug)]
 #[command(version)]
-struct Args;
+struct Args {
+    /// Path to a custom Vale binary to use instead of the managed or system binary
+    #[arg(long, value_name = "PATH")]
+    vale_binary: Option<std::path::PathBuf>,
+}
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
 
-    let _ = Args::parse();
+    let args = Args::parse();
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
+
+    let vale_manager = if let Some(custom_binary) = args.vale_binary {
+        ValeManager::with_custom_binary(Some(custom_binary))
+    } else {
+        ValeManager::new()
+    };
 
     let (service, socket) = LspService::build(|client| Backend {
         client,
         document_map: DashMap::new(),
         param_map: DashMap::new(),
-        cli: ValeManager::new(),
+        cli: vale_manager,
     })
     .finish();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -264,7 +264,8 @@ impl LanguageServer for Backend {
         let context = rope.line(position.line as usize);
         let line = context.as_str().to_owned().unwrap_or("");
 
-        let config = self.cli.config(self.config_path(), self.root_path());
+        let cli = self.get_vale_manager();
+        let config = cli.config(self.config_path(), self.root_path());
         if config.is_err() {
             return Ok(None);
         }
@@ -320,7 +321,8 @@ impl LanguageServer for Backend {
         }
 
         let s = serde_json::to_string(diagnostics.unwrap()).unwrap();
-        match self.cli.fix(&s) {
+        let cli = self.get_vale_manager();
+        match cli.fix(&s) {
             Ok(fixed) => {
                 let alert: vale::ValeAlert = serde_json::from_str(&s).unwrap();
                 let mut range = utils::alert_to_range(alert.clone());
@@ -381,12 +383,12 @@ impl Backend {
         let uri = params.uri.clone();
         let fp = uri.to_file_path();
 
-        let has_cli = self.cli.is_installed();
+        let cli = self.get_vale_manager();
+        let has_cli = cli.is_installed();
 
         self.update(params.clone());
         if has_cli && fp.is_ok() {
-            match self
-                .cli
+            match cli
                 .run(fp.unwrap(), self.config_path(), self.config_filter())
             {
                 Ok(result) => {
@@ -490,6 +492,17 @@ impl Backend {
         None
     }
 
+    fn get_vale_manager(&self) -> vale::ValeManager {
+        let custom_binary = self.get_string("valeBinaryPath");
+        if !custom_binary.is_empty() {
+            let custom_path = std::path::PathBuf::from(custom_binary);
+            vale::ValeManager::with_custom_binary(Some(custom_path))
+        } else {
+            // Fall back to the default ValeManager stored in self.cli
+            self.cli.clone()
+        }
+    }
+
     fn update(&self, params: TextDocumentItem) {
         let uri = params.uri.clone();
         if self.get_ext(uri) != "" {
@@ -504,7 +517,8 @@ impl Backend {
         if uri.path().contains(".vale.ini") {
             return "ini".to_string();
         } else if ext == "yml" {
-            let config = self.cli.config(self.config_path(), self.root_path());
+            let cli = self.get_vale_manager();
+            let config = cli.config(self.config_path(), self.root_path());
             if config.is_ok() {
                 let styles = config.unwrap().styles_path;
                 let p = styles::StylesPath::new(styles);
@@ -517,7 +531,8 @@ impl Backend {
     }
 
     async fn do_sync(&self) {
-        match self.cli.sync(self.config_path(), self.root_path()) {
+        let cli = self.get_vale_manager();
+        match cli.sync(self.config_path(), self.root_path()) {
             Ok(_) => {
                 self.client
                     .show_message(MessageType::INFO, "Successfully synced Vale config.")
@@ -553,7 +568,8 @@ impl Backend {
             return;
         }
 
-        let resp = self.cli.upload_rule(
+        let cli = self.get_vale_manager();
+        let resp = cli.upload_rule(
             self.config_path(),
             self.root_path(),
             uri.to_str().unwrap().to_string(),

--- a/src/vale.rs
+++ b/src/vale.rs
@@ -101,6 +101,7 @@ pub struct ValeManager {
     pub arch: String,
 
     pub fallback_exe: PathBuf,
+    pub custom_exe: Option<PathBuf>,
 }
 
 // ValeManager manages the installation and execution of Vale.
@@ -113,6 +114,15 @@ impl ValeManager {
     // The ValeManager will attempt to use the managed version of Vale, but
     // will fall back to the system version if it's not available.
     pub fn new() -> ValeManager {
+        ValeManager::with_custom_binary(None)
+    }
+
+    // `with_custom_binary` creates a new ValeManager with an optional custom binary path.
+    //
+    // If `custom_binary` is provided, it will be used as the highest priority Vale executable.
+    // Otherwise, the ValeManager will attempt to use the managed version of Vale, but
+    // will fall back to the system version if it's not available.
+    pub fn with_custom_binary(custom_binary: Option<PathBuf>) -> ValeManager {
         let arch = vale_arch();
 
         let fallback = which("vale").unwrap_or(PathBuf::from(""));
@@ -133,10 +143,14 @@ impl ValeManager {
             args: vec!["--output=JSON".to_string()],
             arch,
             fallback_exe: fallback,
+            custom_exe: custom_binary,
         }
     }
 
     pub(crate) fn is_installed(&self) -> bool {
+        if let Some(ref custom) = self.custom_exe {
+            return custom.exists();
+        }
         self.managed_exe.exists() || self.fallback_exe.exists()
     }
 
@@ -284,6 +298,13 @@ impl ValeManager {
     }
 
     fn exe_path(&self, managed: bool) -> Result<PathBuf, Error> {
+        // Priority order: custom binary -> managed binary -> fallback binary
+        if let Some(ref custom) = self.custom_exe {
+            if custom.exists() {
+                return Ok(custom.clone());
+            }
+        }
+        
         if self.managed_exe.exists() {
             return Ok(self.managed_exe.clone());
         } else if self.fallback_exe.exists() && !managed {


### PR DESCRIPTION
Closes #25 

@jdkato 

I am still being asked for the ability to set custom binary locations with the LSP-based VSCode extension and I made a very vague stab at this… I know no rust, so this was a bunch of copy and pasting and AI coding, resulting in something that doesn't error, but also doesn't seem to work as if I specify `valeBinaryPath` in the VSCode extension with a non-existent binary, it still works…

I just wanted to see if we could push this forward and maybe you throw this code out, but it's hopefully the vaguest of starts.